### PR TITLE
set max num results for ES to k

### DIFF
--- a/zoning/term_extraction/search/__init__.py
+++ b/zoning/term_extraction/search/__init__.py
@@ -29,7 +29,7 @@ def search_for_term(
         case SearchMethod.NONE:
             searcher = DummySearcher()
         case SearchMethod.ELASTICSEARCH:
-            searcher = ElasticSearcher()
+            searcher = ElasticSearcher(k)
         case SearchMethod.EMBEDDINGS_KNN:
             # We grossly inflate the K we use for KNN to ensure that, even after
             # removing all overlapping pages, we have at least k pages leftover

--- a/zoning/term_extraction/search/elasticsearch.py
+++ b/zoning/term_extraction/search/elasticsearch.py
@@ -9,8 +9,9 @@ from .utils import expand_term
 
 
 class ElasticSearcher(Searcher):
-    def __init__(self) -> None:
+    def __init__(self, k: int) -> None:
         self.client = Elasticsearch("http://localhost:9200")  # default client
+        self.k = k 
 
     def search(self, town: str, district: District, term: str):
         # Search in town
@@ -39,8 +40,11 @@ class ElasticSearcher(Searcher):
         )
 
         s.query = district_query & term_query & dim_query
-
+        # ensure that we have a maximum of k results 
+        s = s.extra(size=self.k) 
+        
         s = s.highlight("Text")
+        
         res = s.execute()
 
         yield from (


### PR DESCRIPTION
setting the size attribute of the Searcher should set a maximum number of results that it can return. However, upon running, it seems that ES doesn't return anywhere near that number because it only returns results that match the query. Running with size = 20, ES is still only giving back anywhere form 2 to 8 results for a given run, and it's still stuck at min_lot_size answer accuracy = 0.8

I think it's still good to get this functionality of setting the size through, and then later we can look more into why its returning so much less than that. 