### PR TITLE
Improve Tournament Result from 19/24 to 23/24 by increasing context size

### DIFF
--- a/data/ground_truth.csv
+++ b/data/ground_truth.csv
@@ -23,7 +23,7 @@ bridgewater,C,Commercial,26,,130680,31,,,,,35,31,,10,31,,50,32,,2,45,,"I honestl
 bristol,R-40,Residential R-40,30,,40000,47,,,,35,35,47,20,20,47,,,,2,2,94,,
 brookfield,TCD-P,Town Center Perimeter Overlay,,0.23,10000,85,,,,,42,85,,,,,80,85,,2,124,,no single list of zones
 brooklyn,IND,Industrial,,,87120,86,,,,,35,86,,,86,,,86,,2,164,,no single list of zones
-brooklyn,RB,Restricted Business,,0.459,20000,74,,,,35,35,"74,228",20,20,74,80,80,74,2,2,164,,no single list of zones
+brooklyn,RB,Restricted Business,,0.459,20000,"74,228",,,,35,35,"74,228",20,20,74,80,80,74,2,2,164,,no single list of zones
 burlington,I,Industrial,5,1,43560,58,,,,35,35,58,,,,25,25,58,2,2,61,,No min unit size for I zone?
 canaan-falls-village,Rural Business,Rural Business,,0.92,40000,21,,,,35,35,21,25,25,21,50,50,21,,2,44,,no single list of zones
 canterbury,VC,Village Commercial,,,60000,28,,,,35,35,28,15,,,,,,,2,61,,no single list of zones

--- a/zoning/term_extraction/extract/tournament_reduce.py
+++ b/zoning/term_extraction/extract/tournament_reduce.py
@@ -8,7 +8,7 @@ from .map import MapExtractor
 from .utils import include_context_around_phrase
 
 TOURNAMENT_REDUCE_MAX_ANSWERS_PER_STAGE = 4
-TOURNAMENT_REDUCE_CONTEXT_TOKENS_PER_ANSWER = 2000
+TOURNAMENT_REDUCE_CONTEXT_TOKENS_PER_ANSWER = 3500
 
 tournament_reduce_tmpl = get_jinja_environment().get_template("tournament.pmpt.tpl")
 # tournament_reduce_tmpl = get_jinja_environment().get_template("tournament_allow_none.pmpt.tpl")


### PR DESCRIPTION
- Improve Tournament with nonempty `gt_page` by increasing context size
- Update Brooklyn Restricted Business `min_lot_size` ground truth