### PR TITLE
Set es.index timeout to 30 to avoid index failure on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,4 +172,4 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/zoning/data_processing/index_towns.py
+++ b/zoning/data_processing/index_towns.py
@@ -36,7 +36,7 @@ def index_dataset(d, index_name):
 
         # Truncate to 2000 tokens
         text = enc.decode(enc.encode(text)[:2500])
-        es.index(index=index_name, id=page, document={"Page": page, "Text": text})
+        es.index(index=index_name, id=page, document={"Page": page, "Text": text}, request_timeout=30)
 
 
 def main():


### PR DESCRIPTION
The default 10s timeout for indexing will very likely lead to index failure on windows. I assume the Docker on windows is not as fast as on Linux.

Error message:
```
elasticsearch.exceptions.ConnectionTimeout: ConnectionTimeout caused by - ReadTimeoutError(HTTPConnectionPool(host='localhost', port=9200): Read timed out. (read timeout=10))
```

By setting timeout to 30s will avoid this problem.